### PR TITLE
Update compiler version to 1.75.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,15 +47,15 @@ RUN apt-get update && \
 # Install Rust and the cargo-ament-build plugin
 USER $CONTAINER_USER
 WORKDIR /home/${CONTAINER_USER}
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.74.0 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.75.0 -y
 ENV PATH="/home/${CONTAINER_USER}/.cargo/bin:$PATH"
 RUN cargo install cargo-ament-build
 
-RUN pip install --upgrade pytest 
+RUN pip install --upgrade pytest
 
 # Install the colcon-cargo and colcon-ros-cargo plugins
 RUN pip install git+https://github.com/colcon/colcon-cargo.git git+https://github.com/colcon/colcon-ros-cargo.git
 WORKDIR /home/${CONTAINER_USER}/ros2_rust_workshop/ros_ws/src
 RUN git clone https://github.com/roboticswithjulia/ros2_rust_workshop && git clone https://github.com/ros2-rust/ros2_rust.git && \
     vcs import ~/ros2_rust_workshop/ros_ws/src < ros2_rust/ros2_rust_humble.repos && \
-    git clone --recursive https://github.com/roboticswithjulia/champ.git -b ros2 
+    git clone --recursive https://github.com/roboticswithjulia/champ.git -b ros2


### PR DESCRIPTION
Updated the Rust compiler version to correctly build the packages, as `rclrs` now requires this version of the compiler.